### PR TITLE
fix: prevent opslevel api throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loadsmart/backstage-plugin-opslevel-maturity",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/EntityOpsLevelMaturityContent.tsx
+++ b/src/components/EntityOpsLevelMaturityContent.tsx
@@ -73,9 +73,9 @@ export const EntityOpsLevelMaturityContent = () => {
 
     showSnackbar({ message: "Updating service in OpsLevel...", severity: "info" });
 
-    const exportEntityResult = await opslevelApi.exportEntity(entity);
+    const result = await opslevelApi.exportEntity(entity);
 
-    showSnackbar({ message: exportEntityResult?.import.actionMessage, severity: "success", duration: 5000 });
+    showSnackbar({ message: result?.import.actionMessage, severity: "success", duration: 5000 });
 
     await opslevelApi.updateService(entity)
 

--- a/src/components/ExportEntitiesForm/ExportEntitiesForm.tsx
+++ b/src/components/ExportEntitiesForm/ExportEntitiesForm.tsx
@@ -58,6 +58,9 @@ export function ExportEntitiesForm() {
 
       await opslevelApi.updateService(entity)
 
+      // wait 300ms to avoid opslevel api throttling
+      await new Promise(resolve => setTimeout(resolve, 300));
+
       localOutput += `${finishExportMessage(result)}\n`;
       setOutput(localOutput);
     }


### PR DESCRIPTION
fix the plugin being throttled while exporting all entities in Maturity page